### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3.8.0
         with:
+          distribution: 'zulu'
           java-version: 11
 
       - name: Cache Flutter dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,18 +46,18 @@ jobs:
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
 
       - name: Checkout app repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -83,13 +83,13 @@ jobs:
           npm run seed
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: ${{ runner.tool_cache }}//flutter
           key: flutter-${{ env.FLUTTER_VERSION }}-stable
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@v2.8.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -140,18 +140,18 @@ jobs:
         id: postgres
 
       - name: Checkout app repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: 18.7.0
           cache: 'npm'
@@ -177,18 +177,18 @@ jobs:
           npm run seed
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.8.0
         with:
           java-version: 11
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: ${{ runner.tool_cache }}//flutter
           key: flutter-${{ env.FLUTTER_VERSION }}-stable
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@v2.8.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -217,10 +217,10 @@ jobs:
           curl http://localhost:4000 -I
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.3.3
       
       - name: AVD cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         id: avd-cache
         with:
           path: |
@@ -230,7 +230,7 @@ jobs:
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != true
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.27.0
         with:
           api-level: ${{ matrix.api-level }}
           profile: Nexus 5
@@ -243,7 +243,7 @@ jobs:
 
       - name: Run integration tests
         # more info on https://github.com/ReactiveCircus/android-emulator-runner
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.27.0
         with:
           api-level: ${{ matrix.api-level }}
           profile: Nexus 5

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gradle/gradle-build-action](https://github.com/gradle/gradle-build-action)** published a new release **[v2.3.3](https://github.com/gradle/gradle-build-action/releases/tag/v2.3.3)** on 2022-10-22T14:29:18Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.8.0](https://github.com/actions/setup-java/releases/tag/v3.8.0)** on 2022-12-06T14:20:11Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11)** on 2022-10-13T11:18:20Z
* **[reactivecircus/android-emulator-runner](https://github.com/reactivecircus/android-emulator-runner)** published a new release **[v2.27.0](https://github.com/ReactiveCircus/android-emulator-runner/releases/tag/v2.27.0)** on 2022-10-28T07:33:22Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[subosito/flutter-action](https://github.com/subosito/flutter-action)** published a new release **[v2.8.0](https://github.com/subosito/flutter-action/releases/tag/v2.8.0)** on 2022-10-12T23:34:28Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.5.1](https://github.com/actions/setup-node/releases/tag/v3.5.1)** on 2022-10-13T12:19:17Z
