### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: true
     runs-on: macos-latest # or macos-latest if you prefer, but be aware that the available simulators could be different if you run a different version
     steps:
-      - uses: ikalnytskyi/action-setup-postgres@v3
+      - uses: ikalnytskyi/action-setup-postgres@v4
         with:
           username: postgres
           password: postgres
@@ -46,18 +46,18 @@ jobs:
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
 
       - name: Checkout app repo
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -83,7 +83,7 @@ jobs:
           npm run seed
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: ${{ runner.tool_cache }}//flutter
           key: flutter-${{ env.FLUTTER_VERSION }}-stable
@@ -139,7 +139,7 @@ jobs:
           #   arch: x86
       fail-fast: false
     steps:
-      - uses: ikalnytskyi/action-setup-postgres@v3
+      - uses: ikalnytskyi/action-setup-postgres@v4
         with:
           username: postgres
           password: postgres
@@ -148,18 +148,18 @@ jobs:
         id: postgres
 
       - name: Checkout app repo
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -185,13 +185,13 @@ jobs:
           npm run seed
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.10.0
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: ${{ runner.tool_cache }}//flutter
           key: flutter-${{ env.FLUTTER_VERSION }}-stable
@@ -229,7 +229,7 @@ jobs:
       #   uses: gradle/gradle-build-action@v2.3.3
       
       # - name: AVD cache
-      #   uses: actions/cache@v3.0.11
+      #   uses: actions/cache@v3.2.6
       #   id: avd-cache
       #   with:
       #     path: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.2.6](https://github.com/actions/cache/releases/tag/v3.2.6)** on 2023-02-21T10:18:08Z
* **[ikalnytskyi/action-setup-postgres](https://github.com/ikalnytskyi/action-setup-postgres)** published a new release **[v4](https://github.com/ikalnytskyi/action-setup-postgres/releases/tag/v4)** on 2023-01-04T00:46:46Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.10.0](https://github.com/actions/setup-java/releases/tag/v3.10.0)** on 2023-02-07T17:00:34Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.6.0](https://github.com/actions/setup-node/releases/tag/v3.6.0)** on 2023-01-05T14:09:37Z
