### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
           npm run seed
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.1.3.1
         with:
           path: ${{ runner.tool_cache }}//flutter
           key: flutter-${{ env.FLUTTER_VERSION }}-stable
@@ -182,13 +182,13 @@ jobs:
           npm run seed
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v3.12.0
         with:
           distribution: "zulu"
           java-version: 11
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.1.3.1
         with:
           path: ${{ runner.tool_cache }}//flutter
           key: flutter-${{ env.FLUTTER_VERSION }}-stable
@@ -223,10 +223,10 @@ jobs:
           curl http://localhost:8080 -I
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.7.0
 
       - name: AVD cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         id: avd-cache
         with:
           path: |

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.12.0](https://github.com/actions/setup-java/releases/tag/v3.12.0)** on 2023-07-24T11:31:29Z
* **[gradle/gradle-build-action](https://github.com/gradle/gradle-build-action)** published a new release **[v2.7.0](https://github.com/gradle/gradle-build-action/releases/tag/v2.7.0)** on 2023-07-24T16:37:40Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.0)** on 2023-08-06T06:09:30Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.1](https://github.com/actions/cache/releases/tag/v3.3.1)** on 2023-03-13T05:05:19Z
