### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,12 @@ jobs:
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
 
       - name: Checkout app repo
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.1.0
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.1.0
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
@@ -140,12 +140,12 @@ jobs:
         id: postgres
 
       - name: Checkout app repo
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.1.0
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.1.0
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
@@ -177,7 +177,7 @@ jobs:
           npm run seed
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           distribution: "zulu"
           java-version: 11
@@ -213,10 +213,10 @@ jobs:
           curl http://localhost:8080 -I
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2.8.0
+        uses: gradle/gradle-build-action@v2.9.0
 
       - name: AVD cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         id: avd-cache
         with:
           path: |
@@ -256,12 +256,12 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout app repo
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.1.0
         with:
           path: handle-it-app
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           distribution: "zulu"
           java-version: 11

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.13.0](https://github.com/actions/setup-java/releases/tag/v3.13.0)** on 2023-09-20T12:22:38Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.2](https://github.com/actions/cache/releases/tag/v3.3.2)** on 2023-09-07T20:33:08Z
* **[gradle/gradle-build-action](https://github.com/gradle/gradle-build-action)** published a new release **[v2.9.0](https://github.com/gradle/gradle-build-action/releases/tag/v2.9.0)** on 2023-10-01T00:15:58Z
