### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,18 +42,18 @@ jobs:
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
 
       - name: Checkout app repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -79,7 +79,7 @@ jobs:
           npm run seed
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2.10.0
+        uses: subosito/flutter-action@v2.12.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -140,18 +140,18 @@ jobs:
         id: postgres
 
       - name: Checkout app repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -183,7 +183,7 @@ jobs:
           java-version: 11
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2.10.0
+        uses: subosito/flutter-action@v2.12.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -256,7 +256,7 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout app repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           path: handle-it-app
 
@@ -267,7 +267,7 @@ jobs:
           java-version: 11
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2.10.0
+        uses: subosito/flutter-action@v2.12.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[subosito/flutter-action](https://github.com/subosito/flutter-action)** published a new release **[v2.12.0](https://github.com/subosito/flutter-action/releases/tag/v2.12.0)** on 2023-11-01T11:05:55Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.0](https://github.com/actions/setup-node/releases/tag/v4.0.0)** on 2023-10-23T14:55:24Z
