### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,18 +42,18 @@ jobs:
           xcrun simctl boot "${UDID:?No Simulator with this name found}"
 
       - name: Checkout app repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -79,7 +79,7 @@ jobs:
           npm run seed
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2.10.0
+        uses: subosito/flutter-action@v2.14.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -131,7 +131,7 @@ jobs:
           #   arch: x86
       fail-fast: false
     steps:
-      - uses: ikalnytskyi/action-setup-postgres@v4
+      - uses: ikalnytskyi/action-setup-postgres@v5
         with:
           username: postgres
           password: postgres
@@ -140,18 +140,18 @@ jobs:
         id: postgres
 
       - name: Checkout app repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           path: handle-it-app
 
       - name: Checkout server repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           repository: baconcheese113/handle-it-server
           path: handle-it-server
 
       - name: Setup Nodejs
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -177,13 +177,13 @@ jobs:
           npm run seed
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.13.0
+        uses: actions/setup-java@v4.2.1
         with:
           distribution: "zulu"
           java-version: 11
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2.10.0
+        uses: subosito/flutter-action@v2.14.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -213,10 +213,10 @@ jobs:
           curl http://localhost:8080 -I
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2.9.0
+        uses: gradle/gradle-build-action@v3.1.0
 
       - name: AVD cache
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4.0.2
         id: avd-cache
         with:
           path: |
@@ -227,7 +227,7 @@ jobs:
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != true
-        uses: reactivecircus/android-emulator-runner@v2.28.0
+        uses: reactivecircus/android-emulator-runner@v2.30.1
         with:
           api-level: ${{ matrix.api-level }}
           target: playstore
@@ -239,7 +239,7 @@ jobs:
 
       - name: Run integration tests
         # more info on https://github.com/ReactiveCircus/android-emulator-runner
-        uses: reactivecircus/android-emulator-runner@v2.28.0
+        uses: reactivecircus/android-emulator-runner@v2.30.1
         with:
           api-level: ${{ matrix.api-level }}
           target: playstore
@@ -256,18 +256,18 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout app repo
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.1.1
         with:
           path: handle-it-app
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.13.0
+        uses: actions/setup-java@v4.2.1
         with:
           distribution: "zulu"
           java-version: 11
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@v2.10.0
+        uses: subosito/flutter-action@v2.14.0
         with:
           channel: stable
           flutter-version: ${{ env.FLUTTER_VERSION }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.1](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)** on 2024-02-05T21:40:25Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[gradle/gradle-build-action](https://github.com/gradle/gradle-build-action)** published a new release **[v3.1.0](https://github.com/gradle/gradle-build-action/releases/tag/v3.1.0)** on 2024-02-13T20:49:09Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[reactivecircus/android-emulator-runner](https://github.com/reactivecircus/android-emulator-runner)** published a new release **[v2.30.1](https://github.com/ReactiveCircus/android-emulator-runner/releases/tag/v2.30.1)** on 2024-01-26T12:29:45Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.1](https://github.com/actions/setup-java/releases/tag/v4.2.1)** on 2024-03-14T14:29:47Z
* **[subosito/flutter-action](https://github.com/subosito/flutter-action)** published a new release **[v2.14.0](https://github.com/subosito/flutter-action/releases/tag/v2.14.0)** on 2024-03-20T05:17:52Z
* **[ikalnytskyi/action-setup-postgres](https://github.com/ikalnytskyi/action-setup-postgres)** published a new release **[v5](https://github.com/ikalnytskyi/action-setup-postgres/releases/tag/v5)** on 2024-01-09T23:27:30Z
